### PR TITLE
update hostnames

### DIFF
--- a/lib/dropbox_sdk.rb
+++ b/lib/dropbox_sdk.rb
@@ -8,9 +8,9 @@ require 'securerandom'
 require 'pp'
 
 module Dropbox # :nodoc:
-  API_SERVER = "api.dropbox.com"
-  API_CONTENT_SERVER = "api-content.dropbox.com"
-  API_NOTIFY_SERVER = "api-notify.dropbox.com"
+  API_SERVER = "api.dropboxapi.com"
+  API_CONTENT_SERVER = "content.dropboxapi.com"
+  API_NOTIFY_SERVER = "notify.dropboxapi.com"
   WEB_SERVER = "www.dropbox.com"
 
   SERVERS = {


### PR DESCRIPTION
From the [core API docs](https://www.dropbox.com/developers/core/docs):

> Hostnames
> 
> The current list of API hostnames is: api.dropboxapi.com, content.dropboxapi.com, and notify.dropboxapi.com
> 
> Previously, these hostnames were used: api.dropbox.com, api-content.dropbox.com, and api-notify.dropbox.com. These will continue to be supported for v1, but the dropboxapi.com hostnames are preferred.
